### PR TITLE
Index fields placeholders

### DIFF
--- a/mysite/Pickup/forms.py
+++ b/mysite/Pickup/forms.py
@@ -8,13 +8,30 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 
 class PostForm(forms.ModelForm):
-    post_loc = forms.CharField(label="Where are we meeting?", max_length=255, required=True)
-    post_title = forms.CharField(label="What are we playing?", max_length=255, required=True)
-    post_text = forms.CharField(label="What's going on?", max_length=255, required=True)
-    exclude = ('author', 'rsvp_list')
+    post_loc = forms.CharField(
+        label="Where are we meeting?",
+        max_length=255,
+        required=True,
+        widget=forms.TextInput(attrs={'placeholder': 'Enter the location'})
+    )
+    post_title = forms.CharField(
+        label="What are we playing?",
+        max_length=255,
+        required=True,
+        widget=forms.TextInput(attrs={'placeholder': 'Enter the game title'})
+    )
+    post_text = forms.CharField(
+        label="What's going on?",
+        max_length=255,
+        required=True,
+        widget=forms.Textarea(attrs={'placeholder': 'Enter a description'})
+    )
+
     class Meta:
         model = models.Post
         fields = ('post_text', 'post_loc', 'post_title')
+        exclude = ('author', 'rsvp_list')
+
     
 
 class RegistrationForm(UserCreationForm):

--- a/mysite/Pickup/static/css/login.css
+++ b/mysite/Pickup/static/css/login.css
@@ -1,12 +1,23 @@
-#cont{
+/* Adjust width of input fields */
+input[type="text"], input[type="password"] {
+    width: 300px; /* Adjust this to match the old size */
+    padding: 10px; /* Optional: add some padding to make it more comfortable */
+    border-radius: 5px; /* Keep it consistent with the button style */
+    border: 1px solid #ccc;
+}
+
+#cont {
     padding: 10%;
 }
-.logTitle{
+
+.logTitle {
     color: black;
 }
-body{
+
+body {
     background: aliceblue;
 }
+
 /* Header Styling */
 header {
     background-color: rgb(157, 213, 255);
@@ -19,29 +30,12 @@ h1 {
     font-size: 2.5em;
 }
 
-/* Login Form Styling */
-#login-container {
+/* Center and align the form */
+.form {
+    margin: auto;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
-    height: calc(100vh - 60px); /* Adjusting for header */
-    background-color: #ffffff;
-}
-
-#login {
-    background-color: white;
-    border-radius: 10px;
-    padding: 30px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    max-width: 400px;
-    width: 100%;
-    text-align: center;
-}
-
-label {
-    display: block;
-    margin-bottom: 5px;
-    font-weight: bold;
 }
 
 button {
@@ -50,7 +44,7 @@ button {
     padding: 10px;
     border: none;
     border-radius: 5px;
-    width: 100%;
+    width: 100px;
     cursor: pointer;
 }
 

--- a/mysite/Pickup/templates/index.html
+++ b/mysite/Pickup/templates/index.html
@@ -8,7 +8,6 @@
     <h1>Pickup Forum</h1>
     <a href="/login/"><h2>Login</h2></a>
     </header>
-    </div>
     <section class="content-wrapper">
         <aside>
             <h2>Post a New Game</h2>        <!-- Form for posting a new activity -->
@@ -16,15 +15,15 @@
                 {%csrf_token%}
                 <div class="form-group">
                     <label for="post_title">Title</label>
-                    {{form.post_title}}
+                    {{ form.post_title }}
                 </div>
                 <div class="form-group">
                     <label for="post_text">Description</label>
-                    {{form.post_text}}
+                    {{ form.post_text }}
                 </div>
                 <div class="form-group">
                     <label for="post_loc">Location</label>
-                    {{form.post_loc}}
+                    {{ form.post_loc }}
                 </div>
                 <input type="submit" value="Submit Post" class="button btn-primary">
             </form>
@@ -32,7 +31,7 @@
 
         <section id="posts">
             <h2>Latest Game Posts</h2>
-            {% verbatim  %}     <!-- Post loading loop -->
+            {% verbatim %}
             <div id="post-list">
                 <div v-for="p in posts">
                     <div class="card post-card">
@@ -49,11 +48,11 @@
                     </div>
                 </div>
             </div>
-            {% endverbatim  %}
+            {% endverbatim %}
         </section>
     </section>
     <footer class='footer'>
-        <p> &nbsp; <!-- footer content here, like copyright etc, use '&copy;' --> </p>
+        <p>&nbsp;</p> <!-- footer content here, like copyright etc, use '&copy;' -->
     </footer>
 {% endblock %}
 {% block scripts %}

--- a/mysite/Pickup/templates/index.html
+++ b/mysite/Pickup/templates/index.html
@@ -14,15 +14,12 @@
             <form action="/upload/" method="POST">
                 {%csrf_token%}
                 <div class="form-group">
-                    <label for="post_title">Title</label>
                     {{ form.post_title }}
                 </div>
                 <div class="form-group">
-                    <label for="post_text">Description</label>
                     {{ form.post_text }}
                 </div>
                 <div class="form-group">
-                    <label for="post_loc">Location</label>
                     {{ form.post_loc }}
                 </div>
                 <input type="submit" value="Submit Post" class="button btn-primary">

--- a/mysite/Pickup/templates/registration/login.html
+++ b/mysite/Pickup/templates/registration/login.html
@@ -1,21 +1,24 @@
-{% extends 'base.html' %}
+{% extends 'base.html' %} 
 {% load static %}
 {% block stylo %}
 <link rel="stylesheet" href="{% static 'css/login.css' %}">
 {% endblock stylo %}
 {% block content %}
 <div class="container text-center" id="cont">
-    <h1 class="logTitle">Login</h1>
+    <h1 class="logTitle">Log in to your Pickup Account</h1> <!-- Title with lowercase "u" -->
     <div class='column'>
-        <form class='form' action="/login/" method="post">  <!-- Login form -->
-            {%csrf_token%}
-            <div class="form-group">{{form.username}}</div>
-            <div class="form-group">{{form.password}}</div>
-            <!-- {{form}} -->
+        <form class='form' action="/login/" method="post">
+            {% csrf_token %}
+            <div class="form-group">
+                <input type="text" name="username" placeholder="Username" class="form-control"> <!-- Manually added field with placeholder -->
+            </div>
+            <div class="form-group">
+                <input type="password" name="password" placeholder="Password" class="form-control"> <!-- Manually added field with placeholder -->
+            </div>
             <input type="submit" value="Login" class="button btn-primary">
-            <input type="hidden" name="next" value="{{request.GET.next}}">
+            <input type="hidden" name="next" value="{{ request.GET.next }}">
         </form>
-        <a href="/register/" class="link text-center">New here?</a>
+        <a href="/register/" class="link text-center">New here? Create a Pickup Account</a>
     </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
Added greyed out placeholders to the input fields that disappear when the user starts to fill the title, description, and location fields in index.html.  Also removed the original labels in the second commit that is included in this pull request. 

Also also, I added a widget in forms.py for the placeholders, which we could add for the login page too but those were added manually in the html. The widgets are like this: "widget=forms.TextInput(attrs={'placeholder': 'Enter the location'})"